### PR TITLE
README.md: additional noncore platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The following platforms will eventually be included in the build and **test-all*
   * MinGW 32-bit
   * MinGW 64-bit
   * POWER8 (pending V8 changes and acceptance by the core team)
+  * GNU Hurd
+  * MIPS
 
 
 CI Software


### PR DESCRIPTION
A problem that prevents `node` releases getting packaged for debian and ubuntu is the need to compile on all required debian platforms.  Currently new versions of `node` are breaking on MIPS and GNU hurd, mainly due to minor libuv problems (eg missing headers, undefined constants).

Aiming to at least test those platforms would help keep fresh `io.js` versions coming to debian/ubuntu users through "official" channels.