### PR TITLE
Added iojs.org web setup Ansible playbook

### DIFF
--- a/setup/www/README.md
+++ b/setup/www/README.md
@@ -1,0 +1,25 @@
+# io.js Website Setup
+
+This directory contains an Ansible playbook to set up the iojs.org website from a fresh Ubuntu host (Upstart configuration assumes 14.04 or similar).
+
+This setup listens to the [iojs/iojs.github.io](https://github.com/iojs/iojs.github.io) repository for new commits on the *master* branch. The changes are pulled locally and copied (sans the *.git* directory) into a publicly served directory.
+
+The inventory uses the host `iojs-www`, the easiest way to link this is to add it to your *~/.ssh/config*, something like:
+
+```text
+Host iojs-www
+  HostName 104.236.136.193
+  User root
+```
+
+This setup assumes a GitHub Webhook is configured ([here](https://github.com/iojs/iojs.github.io/settings/hooks)) to point to port `9999` of the server with the path `/webhook` plus an additional secret.
+
+Note that the *host_vars/iojs-www* file needs to be created, the *host_vars/iojs-www.tmpl* file can be used as a template and simply add the GitHub Webhook secret.
+
+An SSL certificate should also be provided along with a key. The certificate, along with chain, should be placed in *resources/iojs_chained.crt* and the key in *resources/iojs.key*.
+
+To set up the web server, run:
+
+```text
+$ ansible-playbook -i ansible-inventory ansible-playbook.yaml
+```

--- a/setup/www/ansible-inventory
+++ b/setup/www/ansible-inventory
@@ -1,0 +1,2 @@
+[iojs-www]
+iojs-www

--- a/setup/www/ansible-playbook.yaml
+++ b/setup/www/ansible-playbook.yaml
@@ -1,0 +1,108 @@
+---
+- hosts: iojs-www
+
+  remote_user: root
+
+  tasks:
+    - include_vars: ansible-vars.yaml
+      tags: vars
+
+    - name: General | APT Update
+      apt: update_cache=yes
+      tags: general
+
+    - name: General | APT Upgrade
+      apt: upgrade=full
+      tags: general
+
+    # Not strictly required at the moment, intended to be used with a
+    # Docker webhook updater, _maybe_
+    - name: Node.js | Add the NodeSource Node.js repo
+      command: "bash -c 'curl -sL https://deb.nodesource.com/setup | bash -'"
+      tags: node
+
+    - name: General | Install required packages
+      apt: name={{ item }} update_cache=yes state=latest
+      with_items: packages
+      tags: general
+
+    - name: User | Add {{ server_user }} user
+      user: name="{{ server_user }}" shell=/bin/bash
+      tags: user
+
+    - name: User | Download pubkey(s)
+      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
+      delegate_to: 127.0.0.1
+      with_items: ssh_users
+      tags: user
+
+    - name: General | Create authorized_keys for root
+      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
+      with_items: ssh_users
+      tags: user
+
+    - name: General | Create authorized_keys for {{ server_user }}
+      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
+      with_items: ssh_users
+      tags: user
+
+    - name: GitHub Webhook | Install github-webhook
+      command: "npm install github-webhook -g"
+      tags: webhook
+
+    - name: GitHub Webhook | Copy config
+      copy: src=./resources/github-webhook.json dest=/etc/github-webhook.json mode=0644
+      tags: webhook
+
+    - name: GitHub Webhook | Copy secret to config
+      replace: dest=/etc/github-webhook.json regexp="\{\{github_secret\}\}" replace="{{ github_secret }}"
+      tags: webhook
+
+    - name: GitHub Webhook | Copy update command to config
+      replace: dest=/etc/github-webhook.json regexp="\{\{update_command\}\}" replace="{{ update_command }}"
+      tags: webhook
+
+    - name: GitHub Webhook | Copy Upstart config
+      copy: src=./resources/github-webhook.conf dest=/etc/init/github-webhook.conf mode=0644
+      tags: webhook
+
+    - name: GitHub Webhook | Start service
+      service: name=github-webhook state=started
+      tags: webhook
+
+    - name: Setup | Initial clone
+      remote_user: "{{ server_user }}"
+      command: "bash -c '{{ clone_command }}'"
+      tags: setup
+
+    - name: Setup | Initial update
+      remote_user: "{{ server_user }}"
+      command: "bash -c '{{ update_command }}'"
+      tags: setup
+
+    - name: nginx | Copy site config
+      copy: src=./resources/iojs.org dest=/etc/nginx/sites-available/iojs.org mode=0644
+      tags: nginx
+
+    - name: nginx | Create config symlink
+      file: src=/etc/nginx/sites-available/iojs.org dest=/etc/nginx/sites-enabled/00-iojs.org state=link
+      tags: nginx
+
+    - name: nginx | Generate DH params
+      command: "bash -c 'mkdir -p /etc/nginx/ssl/ && openssl dhparam -out /etc/nginx/ssl/dhparam.pem 4096'"
+      tags: nginx
+
+    - name: nginx | Copy site certificates
+      copy: src=./resources/{{ item }} dest=/etc/nginx/ssl/{{ item }} mode=0644
+      with_items:
+        - iojs_chained.crt
+        - iojs.key
+      tags: nginx
+
+    - name: nginx | Delete default config
+      file: path=/etc/nginx/sites-enabled/default state=absent
+      tags: nginx
+
+    - name: nginx | Restart service
+      service: name=nginx state=restarted
+      tags: webhook

--- a/setup/www/ansible-vars.yaml
+++ b/setup/www/ansible-vars.yaml
@@ -1,0 +1,9 @@
+---
+server_user: iojs
+ssh_users:
+  - rvagg
+  - indutny
+packages:
+  - nodejs
+  - nginx
+  - git

--- a/setup/www/host_vars/.gitignore
+++ b/setup/www/host_vars/.gitignore
@@ -1,0 +1,1 @@
+iojs-www

--- a/setup/www/host_vars/iojs-www.tmpl
+++ b/setup/www/host_vars/iojs-www.tmpl
@@ -1,0 +1,4 @@
+---
+github_secret: "INSERT SECRET FROM WEBHOOK HERE"
+clone_command: "cd /home/iojs/ && rm -rf iojs.github.io && git clone https://github.com/iojs/iojs.github.io.git"
+update_command: "cd /home/iojs/iojs.github.io/ && git checkout master && git reset --hard && git clean -fdx && git pull origin master && rsync -avz --delete --exclude .git /home/iojs/iojs.github.io/ /home/iojs/www/"

--- a/setup/www/resources/.gitignore
+++ b/setup/www/resources/.gitignore
@@ -1,0 +1,2 @@
+iojs_chained.crt
+iojs.key

--- a/setup/www/resources/github-webhook.conf
+++ b/setup/www/resources/github-webhook.conf
@@ -1,0 +1,9 @@
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+respawn limit 10 5
+
+setuid iojs
+
+exec github-webhook --config /etc/github-webhook.json

--- a/setup/www/resources/github-webhook.json
+++ b/setup/www/resources/github-webhook.json
@@ -1,0 +1,11 @@
+{
+  "port": 9999,
+  "path": "/webhook",
+  "secret": "{{github_secret}}",
+  "log": "/var/log/github-webhook.log",
+  "rules": [{
+    "event": "push",
+    "match": "ref == \"refs/heads/master\" && repository.full_name == \"iojs/iojs.github.io\"",
+    "exec": "{{update_command}}"
+  }]
+}

--- a/setup/www/resources/iojs.org
+++ b/setup/www/resources/iojs.org
@@ -1,0 +1,54 @@
+server {
+    listen 80;
+    return 301 https://iojs.org$request_uri;
+}
+
+server {
+    listen 443 ssl spdy;
+
+    server_name iojs.org;
+
+    ssl_certificate ssl/iojs_chained.crt;
+    ssl_certificate_key ssl/iojs.key;
+    ssl_trusted_certificate ssl/iojs_chained.crt;
+    ssl_dhparam ssl/dhparam.pem;
+
+    ssl_ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS;
+    ssl_prefer_server_ciphers on;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 24h;
+
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    spdy_keepalive_timeout 300;
+    spdy_headers_comp 9;
+
+    resolver 8.8.4.4 8.8.8.8 valid=300s;
+    resolver_timeout 10s;
+
+    add_header Strict-Transport-Security max-age=63072000;
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+
+    access_log /var/log/nginx/iojs.org-access.log;
+    error_log /var/log/nginx/iojs.org-error.log;
+
+    gzip on;
+    gzip_static on;
+    gzip_disable "MSIE [1-6]\.";
+    default_type text/html;
+    gzip_types text/plain text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+    if ($host ~* ^www\.){
+        rewrite ^(.*)$ https://iojs.org$1;
+    }
+
+    location / {
+        root /home/iojs/www;
+        index index.html;
+        default_type text/plain;
+    }
+}


### PR DESCRIPTION
This PR adds an Ansible playbook to set up an iojs.org web server. It's already been run against host `104.236.136.193` which just needs an SSL certificate and an nginx restart.

The server is listening to a GitHub Webhook for [iojs/iojs.github.io](https://github.com/iojs/iojs.github.io) and any commits to master will trigger a sync to the served files, so it should be pretty autonomous.

@indutny you have root access to 104.236.136.193. the certificate chain goes in */etc/nginx/ssl/iojs_chained.crt* and the key in */etc/nginx/ssl/iojs.key*, nginx can be restarted with `service nginx restart`. If you want to change the server setup at all can you either edit these setup files or at least provide details in this repo about what you've done so we can have the setup scripted properly.