### PR TITLE
Dockerfile & instructions for generating debs for GCC 4.9 on weezy

### DIFF
--- a/setup/debian-wheezy-gcc/Dockerfile
+++ b/setup/debian-wheezy-gcc/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:wheezy
+
+MAINTAINER Rod Vagg <rvagg@nodesource.com>
+
+RUN echo 'deb-src http://http.debian.net/debian/ jessie main non-free contrib' >> /etc/apt/sources.list
+
+RUN apt-get update
+
+RUN apt-get install -y fakeroot build-essential devscripts g++-multilib libc6-dbg m4 libtool autoconf2.64 autogen gawk zlib1g-dev systemtap-sdt-dev flex gdb locales sharutils procps libantlr-java libffi-dev fastjar libmagic-dev zip libasound2-dev libxtst-dev libxt-dev libart-2.0-dev libcairo2-dev dejagnu chrpath quilt doxygen ghostscript texlive-latex-base xsltproc libxml2-utils docbook-xsl-ns binutils-multiarch gperf bison texinfo libecj-java libgtk2.0-dev libcloog-isl-dev libmpc-dev libmpfr-dev libgmp-dev realpath graphviz libcloog-isl-dev libmpc-dev
+
+RUN cd /usr/src/ && apt-get source gcc-4.9/jessie
+
+ADD deb-control.patch /usr/src/
+
+RUN cd /usr/src/gcc-4.9-4.9.2/debian && patch -p0 < /usr/src/deb-control.patch
+
+VOLUME [ "/opt/debs" ]
+
+CMD cd /usr/src/gcc-4.9-4.9.2/debian && debuild -uc -us && cp /usr/src/*.deb /opt/debs

--- a/setup/debian-wheezy-gcc/README.md
+++ b/setup/debian-wheezy-gcc/README.md
@@ -1,0 +1,13 @@
+## gcc 4.9 package creation for Debian wheezy
+
+On any Docker-capable Linux system, run:
+
+```text
+docker build -t debian-wheezy-gcc-49 .
+mkdir /tmp/debs
+docker run -v /tmp/debs:/opt/debs debian-wheezy-gcc-49
+```
+
+And .deb files will be magically placed into */tmp/debs*. Note that this depends specifically on the ***gcc-4.9-4.9.2*** package currently shipped with jessie, if this version changes then the deb-control.patch file will probably need to be adjusted.
+
+Note that the tests are still on for the builds and it will take a long time to complete, so don't expect this to happen quickly.

--- a/setup/debian-wheezy-gcc/deb-control.patch
+++ b/setup/debian-wheezy-gcc/deb-control.patch
@@ -1,0 +1,442 @@
+--- control	2015-01-01 05:55:10.000000000 +0000
++++ _control	2015-01-01 05:56:07.248121976 +0000
+@@ -3,20 +3,20 @@
+ Priority: optional
+ Maintainer: Debian GCC Maintainers <debian-gcc@lists.debian.org>
+ Uploaders: Matthias Klose <doko@debian.org>
+-Standards-Version: 3.9.6
+-Build-Depends: debhelper (>= 5.0.62), dpkg-dev (>= 1.17.11), g++-multilib [amd64 i386 kfreebsd-amd64 mips mips64 mips64el mipsel mipsn32 mipsn32el powerpc ppc64 s390 s390x sparc sparc64 x32], 
+-  libc6.1-dev (>= 2.13-5) [alpha ia64] | libc0.3-dev (>= 2.13-5) [hurd-i386] | libc0.1-dev (>= 2.13-5) [kfreebsd-i386 kfreebsd-amd64] | libc6-dev (>= 2.13-5), libc6-dev (>= 2.13-31) [armel armhf], libc6-dev-amd64 [i386 x32], libc6-dev-sparc64 [sparc], libc6-dev-sparc [sparc64], libc6-dev-s390 [s390x], libc6-dev-s390x [s390], libc6-dev-i386 [amd64 x32], libc6-dev-powerpc [ppc64], libc6-dev-ppc64 [powerpc], libc0.1-dev-i386 [kfreebsd-amd64], lib32gcc1 [amd64 ppc64 kfreebsd-amd64 mipsn32 mipsn32el mips64 mips64el s390x sparc64 x32], libn32gcc1 [mips mipsel mips64 mips64el], lib64gcc1 [i386 mips mipsel mipsn32 mipsn32el powerpc sparc s390 x32], libc6-dev-mips64 [mips mipsel mipsn32 mipsn32el], libc6-dev-mipsn32 [mips mipsel mips64 mips64el], libc6-dev-mips32 [mipsn32 mipsn32el mips64 mips64el], libc6-dev-x32 [amd64 i386], libx32gcc1 [amd64 i386], libc6.1-dbg [alpha ia64] | libc0.3-dbg [hurd-i386] | libc0.1-dbg [kfreebsd-i386 kfreebsd-amd64] | libc6-dbg, 
++Standards-Version: 3.9.5
++Build-Depends: debhelper (>= 5.0.62), dpkg-dev (>= 1.16.0~ubuntu4), g++-multilib [amd64 i386 kfreebsd-amd64 mips mips64 mips64el mipsel mipsn32 mipsn32el powerpc ppc64 s390 s390x sparc sparc64 x32], 
++  libc6.1-dev (>= 2.13-5) [alpha ia64] | libc0.3-dev (>= 2.13-5) [hurd-i386] | libc0.1-dev (>= 2.13-5) [kfreebsd-i386 kfreebsd-amd64] | libc6-dev (>= 2.13-5), libc6-dev (>= 2.13-31) [armel armhf], libc6-dev-amd64 [i386 x32], libc6-dev-sparc64 [sparc], libc6-dev-sparc [sparc64], libc6-dev-s390 [s390x], libc6-dev-s390x [s390], libc6-dev-i386 [amd64 x32], libc6-dev-powerpc [ppc64], libc6-dev-ppc64 [powerpc], libc0.1-dev-i386 [kfreebsd-amd64], lib32gcc1 [amd64 ppc64 kfreebsd-amd64 mipsn32 mipsn32el mips64 mips64el s390x sparc64 x32], libn32gcc1 [mips mipsel mips64 mips64el], lib64gcc1 [i386 mips mipsel mipsn32 mipsn32el powerpc sparc s390 x32], libc6-dev-mips64 [mips mipsel mipsn32 mipsn32el], libc6-dev-mipsn32 [mips mipsel mips64 mips64el], libc6-dev-mips32 [mipsn32 mipsn32el mips64 mips64el], libc6.1-dbg [alpha ia64] | libc0.3-dbg [hurd-i386] | libc0.1-dbg [kfreebsd-i386 kfreebsd-amd64] | libc6-dbg, 
+   kfreebsd-kernel-headers (>= 0.84) [kfreebsd-any], 
+   m4, libtool, autoconf2.64, 
+   libunwind7-dev (>= 0.98.5-6) [ia64], libatomic-ops-dev [ia64], 
+   autogen, gawk, lzma, xz-utils, patchutils, 
+-  zlib1g-dev, systemtap-sdt-dev [linux-any kfreebsd-any hurd-any], 
+-  binutils (>= 2.23.52) | binutils-multiarch (>= 2.23.52), binutils-hppa64 (>= 2.23.52) [hppa], 
++  zlib1g-dev, 
++  binutils (>= 2.22) | binutils-multiarch (>= 2.22), binutils-hppa64 (>= 2.22) [hppa], 
+   gperf (>= 3.0.1), bison (>= 1:2.3), flex, gettext, 
+   gdb, 
+   texinfo (>= 4.3), locales, sharutils, 
+   procps, zlib1g-dev, libantlr-java, python, libffi-dev, fastjar, libmagic-dev, libecj-java (>= 3.3.0-2), zip, libasound2-dev [ !hurd-any !kfreebsd-any], libxtst-dev, libxt-dev, libgtk2.0-dev (>= 2.4.4-2), libart-2.0-dev, libcairo2-dev, netbase, 
+-  libcloog-isl-dev (>= 0.18), libmpc-dev (>= 1.0), libmpfr-dev (>= 3.0.0-9~), libgmp-dev (>= 2:5.0.1~), 
++  libcloog-isl-dev (>= 0.17.0-3), libmpc-dev, libmpfr-dev (>= 3.0.0-9~), libgmp-dev (>= 2:5.0.1~), 
+   dejagnu [!m68k], realpath (>= 1.9.12), chrpath, lsb-release, quilt
+ Build-Depends-Indep: doxygen (>= 1.7.2), graphviz (>= 2.2), ghostscript, texlive-latex-base, xsltproc, libxml2-utils, docbook-xsl-ns, 
+ Homepage: http://gcc.gnu.org/
+@@ -30,7 +30,7 @@
+ Priority: required
+ Depends: ${misc:Depends}
+ Replaces: ${base:Replaces}
+-Breaks: gcc-4.4-base (<< 4.4.7), gcc-4.7-base (<< 4.7.3), gcj-4.4-base (<< 4.4.6-9~), gnat-4.4-base (<< 4.4.6-3~), gcj-4.6-base (<< 4.6.1-4~), gnat-4.6 (<< 4.6.1-5~), dehydra (<= 0.9.hg20110609-2)
++Breaks: gcc-4.4-base (<< 4.4.7), gcj-4.4-base (<< 4.4.6-9~), gnat-4.4-base (<< 4.4.6-3~), gcj-4.6-base (<< 4.6.1-4~), gnat-4.6 (<< 4.6.1-5~), dehydra (<= 0.9.hg20110609-2)
+ Description: GCC, the GNU Compiler Collection (base package)
+  This package contains files common to all languages and libraries
+  contained in the GNU Compiler Collection (GCC).
+@@ -220,39 +220,6 @@
+  This package contains the headers and static library files necessary for
+  building C programs which use libgcc, libgomp, libquadmath, libssp or libitm.
+ 
+-Package: libx32gcc1
+-Architecture: amd64 i386
+-Section: libs
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${misc:Depends}
+-Description: GCC support library (x32)
+- Shared version of the support library, a library of internal subroutines
+- that GCC uses to overcome shortcomings of particular machines, or
+- special needs for some languages.
+-
+-Package: libx32gcc1-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gcc1 (= ${gcc:EpochVersion}), ${misc:Depends}
+-Description: GCC support library (debug symbols)
+- Debug symbols for the GCC support library.
+-
+-Package: libx32gcc-4.9-dev
+-Architecture: amd64 i386
+-Section: libdevel
+-Priority: optional
+-Recommends: ${dep:libcdev}
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libgccbiarch}, ${dep:libsspbiarch},
+- ${dep:libgompbiarch}, ${dep:libitmbiarch}, ${dep:libatomicbiarch},
+- ${dep:libbtracebiarch}, ${dep:libasanbiarch}, ${dep:liblsanbiarch},
+- ${dep:libtsanbiarch}, ${dep:libubsanbiarch},
+- ${dep:libvtvbiarch}, ${dep:libcilkrtsbiarch},
+- ${dep:libqmathbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: GCC support library (x32 development files)
+- This package contains the headers and static library files necessary for
+- building C programs which use libgcc, libgomp, libquadmath, libssp or libitm.
+-
+ Package: gcc-4.9
+ Architecture: any
+ Section: devel
+@@ -435,23 +402,6 @@
+ Description: GCC OpenMP (GOMP) support library (n32 debug symbols)
+  GOMP is an implementation of OpenMP for the C, C++, and Fortran compilers
+ 
+-Package: libx32gomp1
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: GCC OpenMP (GOMP) support library (x32)
+- GOMP is an implementation of OpenMP for the C, C++, and Fortran compilers
+- in the GNU Compiler Collection.
+-
+-Package: libx32gomp1-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gomp1 (= ${gcc:Version}), ${misc:Depends}
+-Description: GCC OpenMP (GOMP) support library (x32 debug symbols)
+- GOMP is an implementation of OpenMP for the C, C++, and Fortran compilers
+-
+ Package: libitm1
+ Section: libs
+ Architecture: any
+@@ -540,26 +490,6 @@
+ # accesses to the memory of a process, enabling easy-to-use synchronization of
+ # accesses to shared memory by several threads.
+ 
+-Package: libx32itm1
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: GNU Transactional Memory Library (x32)
+- This manual documents the usage and internals of libitm. It provides
+- transaction support for accesses to the memory of a process, enabling
+- easy-to-use synchronization of accesses to shared memory by several threads.
+-
+-Package: libx32itm1-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32itm1 (= ${gcc:Version}), ${misc:Depends}
+-Description: GNU Transactional Memory Library (x32 debug symbols)
+- This manual documents the usage and internals of libitm. It provides
+- transaction support for accesses to the memory of a process, enabling
+- easy-to-use synchronization of accesses to shared memory by several threads.
+-
+ Package: libatomic1
+ Section: libs
+ Architecture: any
+@@ -638,24 +568,6 @@
+  library providing __atomic built-in functions. When an atomic call cannot
+  be turned into lock-free instructions, GCC will make calls into this library.
+ 
+-Package: libx32atomic1
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: support library providing __atomic built-in functions (x32)
+- library providing __atomic built-in functions. When an atomic call cannot
+- be turned into lock-free instructions, GCC will make calls into this library.
+-
+-Package: libx32atomic1-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32atomic1 (= ${gcc:Version}), ${misc:Depends}
+-Description: support library providing __atomic built-in functions (x32 debug symbols)
+- library providing __atomic built-in functions. When an atomic call cannot
+- be turned into lock-free instructions, GCC will make calls into this library.
+-
+ Package: libasan1
+ Section: libs
+ Architecture: any
+@@ -736,24 +648,6 @@
+ # AddressSanitizer (ASan) is a fast memory error detector.  It finds
+ # use-after-free and {heap,stack,global}-buffer overflow bugs in C/C++ programs.
+ 
+-Package: libx32asan1
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: AddressSanitizer -- a fast memory error detector (x32)
+- AddressSanitizer (ASan) is a fast memory error detector.  It finds
+- use-after-free and {heap,stack,global}-buffer overflow bugs in C/C++ programs.
+-
+-Package: libx32asan1-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32asan1 (= ${gcc:Version}), ${misc:Depends}
+-Description: AddressSanitizer -- a fast memory error detector (x32 debug symbols)
+- AddressSanitizer (ASan) is a fast memory error detector.  It finds
+- use-after-free and {heap,stack,global}-buffer overflow bugs in C/C++ programs.
+-
+ Package: liblsan0
+ Section: libs
+ Architecture: any
+@@ -834,24 +728,6 @@
+ # LeakSanitizer (Lsan) is a memory leak detector which is integrated
+ # into AddressSanitizer.
+ 
+-Package: libx32lsan0
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: LeakSanitizer -- a memory leak detector (x32)
+- LeakSanitizer (Lsan) is a memory leak detector which is integrated
+- into AddressSanitizer.
+-
+-Package: libx32lsan0-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32lsan0 (= ${gcc:Version}), ${misc:Depends}
+-Description: LeakSanitizer -- a memory leak detector (x32 debug symbols)
+- LeakSanitizer (Lsan) is a memory leak detector which is integrated
+- into AddressSanitizer.
+-
+ Package: libtsan0
+ Section: libs
+ Architecture: any
+@@ -963,26 +839,6 @@
+ # Various computations will be instrumented to detect undefined behavior
+ # at runtime. Available for C and C++.
+ 
+-Package: libx32ubsan0
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: UBSan -- undefined behaviour sanitizer (x32)
+- UndefinedBehaviorSanitizer can be enabled via -fsanitize=undefined.
+- Various computations will be instrumented to detect undefined behavior
+- at runtime. Available for C and C++.
+-
+-Package: libx32ubsan0-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32ubsan0 (= ${gcc:Version}), ${misc:Depends}
+-Description: UBSan -- undefined behaviour sanitizer (x32 debug symbols)
+- UndefinedBehaviorSanitizer can be enabled via -fsanitize=undefined.
+- Various computations will be instrumented to detect undefined behavior
+- at runtime. Available for C and C++.
+-
+ Package: libcilkrts5
+ Section: libs
+ Architecture: any
+@@ -1043,24 +899,6 @@
+  Intel Cilk Plus is an extension to the C and C++ languages to support
+  data and task parallelism.
+ 
+-Package: libx32cilkrts5
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: Intel Cilk Plus language extensions (x32)
+- Intel Cilk Plus is an extension to the C and C++ languages to support
+- data and task parallelism.
+-
+-Package: libx32cilkrts5-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32cilkrts5 (= ${gcc:Version}), ${misc:Depends}
+-Description: Intel Cilk Plus language extensions (x32 debug symbols)
+- Intel Cilk Plus is an extension to the C and C++ languages to support
+- data and task parallelism.
+-
+ Package: libquadmath0
+ Section: libs
+ Architecture: any
+@@ -1143,25 +981,6 @@
+ # A library, which provides quad-precision mathematical functions on targets
+ # supporting the __float128 datatype.
+ 
+-Package: libx32quadmath0
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: GCC Quad-Precision Math Library (x32)
+- A library, which provides quad-precision mathematical functions on targets
+- supporting the __float128 datatype. The library is used to provide on such
+- targets the REAL(16) type in the GNU Fortran compiler.
+-
+-Package: libx32quadmath0-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32quadmath0 (= ${gcc:Version}), ${misc:Depends}
+-Description: GCC Quad-Precision Math Library (x32 debug symbols)
+- A library, which provides quad-precision mathematical functions on targets
+- supporting the __float128 datatype.
+-
+ Package: gobjc++-4.9
+ Architecture: any
+ Priority: optional
+@@ -1245,15 +1064,6 @@
+  This package contains the headers and static library files needed to build
+  GNU ObjC applications.
+ 
+-Package: libx32objc-4.9-dev
+-Architecture: amd64 i386
+-Section: libdevel
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gcc-4.9-dev (= ${gcc:Version}), libx32objc4 (>= ${gcc:Version}), ${shlibs:Depends}, ${misc:Depends}
+-Description: Runtime library for GNU Objective-C applications (x32 development files)
+- This package contains the headers and static library files needed to build
+- GNU ObjC applications.
+-
+ Package: libobjc4
+ Section: libs
+ Architecture: any
+@@ -1324,22 +1134,6 @@
+ Description: Runtime library for GNU Objective-C applications (n32 debug symbols)
+  Library needed for GNU ObjC applications linked against the shared library.
+ 
+-Package: libx32objc4
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: Runtime library for GNU Objective-C applications (x32)
+- Library needed for GNU ObjC applications linked against the shared library.
+-
+-Package: libx32objc4-dbg
+-Section: debug
+-Architecture: amd64 i386
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32objc4 (= ${gcc:Version}), libx32gcc1-dbg (>= ${gcc:EpochVersion}), ${misc:Depends}
+-Description: Runtime library for GNU Objective-C applications (x32 debug symbols)
+- Library needed for GNU ObjC applications linked against the shared library.
+-
+ Package: gfortran-4.9
+ Architecture: any
+ Priority: optional
+@@ -1400,15 +1194,6 @@
+  This package contains the headers and static library files needed to build
+  GNU Fortran applications.
+ 
+-Package: libx32gfortran-4.9-dev
+-Architecture: amd64 i386
+-Section: libdevel
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gcc-4.9-dev (= ${gcc:Version}), libx32gfortran3 (>= ${gcc:Version}), ${shlibs:Depends}, ${misc:Depends}
+-Description: Runtime library for GNU Fortran applications (x32 development files)
+- This package contains the headers and static library files needed to build
+- GNU Fortran applications.
+-
+ Package: libgfortran3
+ Section: libs
+ Architecture: any
+@@ -1488,24 +1273,6 @@
+  Library needed for GNU Fortran applications linked against the
+  shared library.
+ 
+-Package: libx32gfortran3
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: Runtime library for GNU Fortran applications (x32)
+- Library needed for GNU Fortran applications linked against the
+- shared library.
+-
+-Package: libx32gfortran3-dbg
+-Section: debug
+-Architecture: amd64 i386
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gfortran3 (= ${gcc:Version}), ${misc:Depends}
+-Description: Runtime library for GNU Fortran applications (x32 debug symbols)
+- Library needed for GNU Fortran applications linked against the
+- shared library.
+-
+ Package: gccgo-4.9
+ Architecture: any
+ Priority: optional
+@@ -1611,25 +1378,6 @@
+  Library needed for GNU Go applications linked against the
+  shared library.
+ 
+-Package: libx32go5
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Replaces: libx32go3
+-Description: Runtime library for GNU Go applications (x32)
+- Library needed for GNU Go applications linked against the
+- shared library.
+-
+-Package: libx32go5-dbg
+-Section: debug
+-Architecture: amd64 i386
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32go5 (= ${gcc:Version}), ${misc:Depends}
+-Description: Runtime library for GNU Go applications (x32 debug symbols)
+- Library needed for GNU Go applications linked against the
+- shared library.
+-
+ Package: gcj-4.9
+ Section: java
+ Architecture: any
+@@ -1831,19 +1579,6 @@
+  was included up to g++-2.95. The first version of libstdc++-v3 appeared
+  in g++-3.0.
+ 
+-Package: libx32stdc++6
+-Architecture: amd64 i386
+-Section: libs
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gcc1 (>= ${gcc:Version}), ${shlibs:Depends}, ${misc:Depends}
+-Description: GNU Standard C++ Library v3 (x32)
+- This package contains an additional runtime library for C++ programs
+- built with the GNU compiler.
+- .
+- libstdc++-v3 is a complete rewrite from the previous libstdc++-v2, which
+- was included up to g++-2.95. The first version of libstdc++-v3 appeared
+- in g++-3.0.
+-
+ Package: libstdc++-4.9-dev
+ Architecture: any
+ Multi-Arch: same
+@@ -1980,33 +1715,6 @@
+ Description: GNU Standard C++ Library v3 (debugging files)
+  This package contains the shared library of libstdc++ compiled with
+  debugging symbols.
+-
+-Package: libx32stdc++-4.9-dev
+-Architecture: amd64 i386
+-Section: libdevel
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gcc-4.9-dev (= ${gcc:Version}), libx32stdc++6 (>= ${gcc:Version}),
+- libstdc++-4.9-dev (= ${gcc:Version}), ${misc:Depends}
+-Description: GNU Standard C++ Library v3 (development files)
+- This package contains the headers and static library files necessary for
+- building C++ programs which use libstdc++.
+- .
+- libstdc++-v3 is a complete rewrite from the previous libstdc++-v2, which
+- was included up to g++-2.95. The first version of libstdc++-v3 appeared
+- in g++-3.0.
+-
+-Package: libx32stdc++6-4.9-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32stdc++6 (>= ${gcc:Version}),
+- libstdc++-4.9-dev (= ${gcc:Version}), libx32gcc1-dbg (>= ${gcc:EpochVersion}),
+- ${shlibs:Depends}, ${misc:Depends}
+-Conflicts: libx32stdc++6-dbg, libx32stdc++6-4.6-dbg,
+- libx32stdc++6-4.7-dbg, libx32stdc++6-4.8-dbg
+-Description: GNU Standard C++ Library v3 (debugging files)
+- This package contains the shared library of libstdc++ compiled with
+- debugging symbols.
+ 
+ Package: libstdc++-4.9-doc
+ Architecture: all


### PR DESCRIPTION
This is a Dockerfile to make a Docker image based on `debian:weezy` that installs the source of GCC 4.9 from jessie but all of the dependencies from weezy. I've made a patch for the `debian/control` file to make it compile.

When you run the Docker image and pass it an `/opt/debs` volume (i.e. just something local) it'll do the full compile & test of GCC 4.9 and dump all the debs into that volume.

This only works with ***gcc-4.9-4.9.2*** which is what's in jessie right now but it's given me binaries which I've hosted in a repo at https://deb.nodesource.com/weezy-gcc49 and can be installed on a weezy server something like this:

```
apt-get install -y apt-transport-https curl
echo 'deb https://deb.nodesource.com/weezy-gcc49 weezy-gcc49 main' >> /etc/apt/sources.list
curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
apt-get update
apt-get install -y g++-4.9 gcc-4.9 cpp-4.9
ln -sf /usr/bin/gcc-4.9 /usr/bin/gcc
ln -sf /usr/bin/gcc-4.9 /usr/bin/cc
ln -sf /usr/bin/g++-4.9 /usr/bin/g++
```

Which will compile the current io.js/v0.12 (with the addition of `python` & `make` packages) and pass _most_ of the tests (failures are unrelated to compile afaik).