### PR TITLE
www: add .xz & fix .gz mime-types

### DIFF
--- a/setup/www/ansible-playbook.yaml
+++ b/setup/www/ansible-playbook.yaml
@@ -105,6 +105,14 @@
       lineinfile: dest=/etc/nginx/mime.types line='application/octet-stream pkg;' insertafter='^types.*'
       tags: nginx
 
+    - name: nginx | Add .xz mime-type
+      lineinfile: dest=/etc/nginx/mime.types line='application/x-xz xz;' insertafter='^types.*'
+      tags: nginx
+
+    - name: nginx | Use official .gz mime-type
+      lineinfile: dest=/etc/nginx/mime.types line='application/gzip gz;' insertafter='^types.*'
+      tags: nginx
+
     - name: nginx | Restart service
       service: name=nginx state=restarted
       tags: webhook


### PR DESCRIPTION
Hopefully this will let .xz files be downloaded properly.

The gzip one isn't super important, but nginx is just outdated on it.