### PR TITLE
nginx: Enable resumable downloads for release files

### DIFF
--- a/setup/www/resources/iojs.org
+++ b/setup/www/resources/iojs.org
@@ -8,6 +8,8 @@ server {
 
     server_name iojs.org;
 
+    root /home/iojs/www;
+
     ssl_certificate ssl/iojs_chained.crt;
     ssl_certificate_key ssl/iojs.key;
     ssl_trusted_certificate ssl/iojs_chained.crt;
@@ -46,9 +48,7 @@ server {
         rewrite ^(.*)$ https://iojs.org$1;
     }
 
-    location / {
-        root /home/iojs/www;
-        index index.html;
-        default_type text/plain;
+    location ~* (\.xz|\.gz|\.pkg|\.msi)$ {
+        gzip off;
     }
 }


### PR DESCRIPTION
Disabling gzip for the release downloads enables support for the HTTP ranges mechanism, as seen by the advertized header on matching requests:

````
Accept-Ranges: bytes
````

For further explaination on why nginx disables ranges on gzip, [see here](http://forum.nginx.org/read.php?29,238804,238822).