### PR TITLE
smartos: remove extended network privileges

### DIFF
--- a/setup/smartos/resources/jenkins_manifest.xml
+++ b/setup/smartos/resources/jenkins_manifest.xml
@@ -15,7 +15,7 @@
         </dependency>
 
         <method_context working_directory="/home/iojs">
-            <method_credential user='iojs' group='iojs' privileges='basic,net_privaddr' />
+            <method_credential user='iojs' group='iojs' privileges='basic' />
             <method_environment>
                 <envvar name='NODE_COMMON_PIPE' value='/home/iojs/test.pipe' />
                 <envvar name='OSTYPE' value='solaris' />


### PR DESCRIPTION
Using net_privaddr caused two tests assuming regular users cannot use privileged port ranges to fail. We should probably not be testing in such an environment anyway.

Passing suite here: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/nodes=iojs-smartos14-64/329/console

R=@geek, @rvagg 