### PR TITLE
smartos: Add HOME environment variable

### DIFF
--- a/setup/smartos/resources/jenkins_manifest.xml
+++ b/setup/smartos/resources/jenkins_manifest.xml
@@ -19,6 +19,7 @@
             <method_environment>
                 <envvar name='NODE_COMMON_PIPE' value='/home/iojs/test.pipe' />
                 <envvar name='OSTYPE' value='solaris' />
+                <envvar name='HOME' value='/home/iojs' />
                 <envvar name='JOBS' value='8' />
                 <envvar name='DESTCPU' value='{{destcpu}}' />
                 <envvar name='PATH' value='/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin' />


### PR DESCRIPTION
gyp refuses to work without a HOME variable. Since svc doesn't launch from a shell, pass it instead.

Jenkins: now featuring blue smartos lights: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/331/

/R=@rvagg, @geek
