### PR TITLE
dist: Support FreeBSD

### DIFF
--- a/setup/ansible-inventory
+++ b/setup/ansible-inventory
@@ -28,6 +28,12 @@ iojs-build-ubuntu1004-32-1
 iojs-build-smartos-64-1
 iojs-build-smartos-32-1
 
+[iojs-build-freebsd101-32]
+iojs-build-freebsd101-32-1
+
+[iojs-build-freebsd101-64]
+iojs-build-freebsd101-64-1
+
 [iojs-build-containers]
 iojs-build-containers-1
 iojs-build-containers-2
@@ -54,3 +60,7 @@ iojs-build-centos5
 
 [iojs-smartos:children]
 iojs-build-smartos
+
+[iojs-freebsd-101:children]
+iojs-build-freebsd101-32
+iojs-build-freebsd101-64

--- a/setup/freebsd/README.md
+++ b/setup/freebsd/README.md
@@ -1,0 +1,26 @@
+# io.js Build FreeBSD Setup
+
+The current FreeBSD lives behind a VPN at [Voxer](http://voxer.com).
+Should you need access, speak to [https://github.com/rvagg](rvagg) for
+further information.
+
+To set up hosts, make sure you add them to your ssh config first:
+```
+Host iojs-build-freebsd-64-1
+  HostName 172.16.31.2
+
+Host iojs-build-freebsd-32-1
+  HostName 172.16.31.3
+```
+
+Note that these hostnames are also used in the ansible-inventory file. The IP addresses will need to be updated each time the servers are reprovisioned.
+
+To set up a host, run:
+
+```text
+$ ansible-playbook -i ../ansible-inventory ansible-playbook.yaml
+```
+
+**Users**: The ansible-vars.yaml file contains a list of users who's GitHub public keys are pulled and placed into
+authorized_keys for both root and iojs users. This file should be updates when new users are added to the build project
+who are able to help maintain the containerized builds.

--- a/setup/freebsd/ansible-playbook.yaml
+++ b/setup/freebsd/ansible-playbook.yaml
@@ -1,0 +1,73 @@
+---
+- hosts: iojs-freebsd-101
+
+  remote_user: root
+
+  vars:
+    - ansible_python_interpreter: "/usr/bin/env python"
+
+  tasks:
+
+    - include_vars: ansible-vars.yaml
+      tags: vars
+
+    - name: General | Update packages
+      command: pkg update
+      tags: general
+
+    - name: General | Install required packages
+      command: pkg install -U -y  {{ item }}
+      with_items: packages
+      tags: general
+
+    - name: User | Add {{ server_user }} group
+      group: name="{{ server_user }}" state=present
+      tags: user
+
+    - name: User | Add {{ server_user }} user
+      user: name="{{ server_user }}" shell=/bin/sh append=yes groups={{ server_user }}
+      tags: user
+
+    - name: User | Download pubkey(s)
+      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
+      delegate_to: 127.0.0.1
+      with_items: ssh_users
+      tags: user
+
+    - name: General | Create authorized_keys for root
+      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
+      with_items: ssh_users
+      tags: user
+
+    - name: General | Create authorized_keys for {{ server_user }}
+      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
+      with_items: ssh_users
+      tags: user
+
+    - name: Jenkins | Download Jenkins' slave.jar
+      command: curl -sL https://jenkins-iojs.nodesource.com/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar
+      tags: jenkins
+
+    - name: Jenkins | Copy init script
+      copy: src=./resources/jenkins dest={{ init_script_path }} owner={{ server_user }} group={{ server_user }} mode=0755
+      tags: jenkins
+
+    - name: Jenkins | Copy interface info into script
+      replace: dest={{ init_script_path }} regexp="\{\{interface\}\}" replace="{{ ansible_all_ipv4_addresses[0] }}"
+      tags: jenkins
+
+    - name: Jenkins | Copy secret into init script
+      replace: dest={{ init_script_path }} regexp="\{\{secret\}\}" replace="{{ server_secret }}"
+      tags: jenkins
+
+    - name: Jenkins | Copy server id into init script
+      replace: dest={{ init_script_path }} regexp="\{\{id\}\}" replace="{{ server_id }}"
+      tags: jenkins
+
+    - name: Jenkins | Enable init script at startup
+      command: echo "jenkins_enable=YES" >> /etc/rc.conf
+      tags: jenkins
+
+    - name: Jenkins | Start service
+      command: service jenkins enable
+      tags: jenkins

--- a/setup/freebsd/ansible-vars.yaml
+++ b/setup/freebsd/ansible-vars.yaml
@@ -1,0 +1,10 @@
+---
+server_user: iojs
+init_script_path: /usr/local/etc/rc.d/jenkins
+ssh_users:
+  - rvagg
+  - jbergstroem
+packages:
+  - openjdk
+  - git
+  - gmake

--- a/setup/freebsd/host_vars/.gitignore
+++ b/setup/freebsd/host_vars/.gitignore
@@ -1,0 +1,1 @@
+iojs-build-freebsd101-*

--- a/setup/freebsd/resources/jenkins
+++ b/setup/freebsd/resources/jenkins
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+# $FreeBSD: $
+#
+# Based on the jenkins init script
+#
+# PROVIDE: jenkins-iojs
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+
+#
+# Configuration settings for jenkins in /etc/rc.conf:
+#
+# jenkins_enable (bool):
+#   Set to "NO" by default.
+#   Set it to "YES" to enable jenkins
+#
+
+. /etc/rc.subr
+
+name="jenkins"
+rcvar=jenkins_enable
+
+load_rc_config "${name}"
+
+
+OSTYPE="freebsd"
+NODE_COMMON_PIPE="/home/iojs/test.pipe"
+LOCALHOST="{{interface}}"
+
+jenkins_jnlpurl="https://jenkins-iojs.nodesource.com/computer/iojs-voxer-freebsd101-{{id}}/slave-agent.jnlp"
+jenkins_secret="{{secret}}"
+jenkins_jar="/home/iojs/slave.jar"
+jenkins_log_file="/home/iojs/jenkins_console.log"
+jenkins_args="-jnlpUrl ${jenkins_jnlpurl} -secret ${jenkins_secret}"
+jenkins_user="iojs"
+jenkins_group="iojs"
+
+pidfile="/var/run/jenkins/jenkins.pid"
+command="/usr/sbin/daemon"
+java_cmd="/usr/local/bin/java"
+procname="/usr/local/openjdk7/bin/java"
+command_args="-p ${pidfile} ${java_cmd} -jar ${jenkins_jar} ${jenkins_args} > ${jenkins_log_file} 2>&1"
+env="LOCALHOST=${LOCALHOST} OSTYPE=${OSTYPE} NODE_COMMON_PIPE=${NODE_COMMON_PIPE} CC=cc CXX=c++"
+required_files="${java_cmd}"
+
+start_precmd="jenkins_prestart"
+start_cmd="jenkins_start"
+
+jenkins_prestart() {
+	if [ ! -f "${jenkins_log_file}" ]; then
+		touch "${jenkins_log_file}"
+		chown "${jenkins_user}:${jenkins_group}" "${jenkins_log_file}"
+		chmod 640 "${jenkins_log_file}"
+	fi
+	if [ ! -d "/var/run/jenkins" ]; then
+		install -d -o "${jenkins_user}" -g "${jenkins_group}" -m 750 "/var/run/jenkins"
+	fi
+
+	if [ $jenkins_secret == "{{secret}}" ]; then
+		err 1 "You need to change the jenkins secret"
+	fi
+}
+
+jenkins_start()
+{
+	check_startmsgs && echo "Starting ${name}."
+	su -l ${jenkins_user} -c "${env} exec ${command} ${command_args}"
+}
+
+run_rc_command "$1"


### PR DESCRIPTION
Add setup scripts for two builders behind a vpn at Voxer. The configuration assumes you're deploying in a FreeBSD jail; we look up the default routed ip-adress through ansible and pass it to the init script.

/R=@rvagg