### PR TITLE
Remove Walmart from hardware providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ The following companies are contributing hardware to this project:
 * [DigitalOcean](http://digitalocean.com/) (via Mikeal Rogers)
 * [Rackspace](http://rackspace.com/) (via Paul Querna)
 * [IBM](http://www.ibm.com/) / [Softlayer](http://www.softlayer.com/) (via Dave Ings and Andrew Low)
-* [Walmart](http://www.walmartlabs.com/) (via Wyatt Preul)
 * [Joyent](http://joyent.com/) (via TJ Fontaine)
 
 


### PR DESCRIPTION
Walmart temporarily provided hardware (hat tip Wyatt Preul <wpreul@gmail.com>) which were replaced by VMs from Joyent.

With this merged I'll also remove the slave from Jenkins.

/R=@geek