### PR TITLE
smartos: enable building with ccache

### DIFF
--- a/setup/smartos/ansible-playbook.yaml
+++ b/setup/smartos/ansible-playbook.yaml
@@ -47,6 +47,17 @@
       authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
       with_items: ssh_users
       tags: user
+      
+    - name: CCache | Create directory that hold symlinks to ccache
+      file: path=/opt/local/libexec/ccache state=directory mode=0755
+      tags: ccache
+    
+    - name: CCache | Symlink compiler binaries to ccache
+      file: src={{ item.src }} dest={{ item.dest }} state=link
+      with_items: 
+        - { src: '/opt/local/bin/ccache', dest: '/opt/local/libexec/ccache/gcc' }
+        - { src: '/opt/local/bin/ccache', dest: '/opt/local/libexec/ccache/g++' }
+      tags: ccache
 
     - name: Jenkins | Download Jenkins' slave.jar
       command: curl -sL https://jenkins-iojs.nodesource.com/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar

--- a/setup/smartos/ansible-vars.yaml
+++ b/setup/smartos/ansible-vars.yaml
@@ -16,3 +16,4 @@ packages:
   - gmake
   - automake
   - libtool
+  - ccache

--- a/setup/smartos/resources/jenkins_manifest.xml
+++ b/setup/smartos/resources/jenkins_manifest.xml
@@ -22,7 +22,7 @@
                 <envvar name='HOME' value='/home/iojs' />
                 <envvar name='JOBS' value='8' />
                 <envvar name='DESTCPU' value='{{destcpu}}' />
-                <envvar name='PATH' value='/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin' />
+                <envvar name='PATH' value='/usr/local/libexec/ccache:/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin' />
             </method_environment>
         </method_context>
 


### PR DESCRIPTION
We need to symlink ourselves since the package manager doesn't do it for us.

Edit: This PR also requires jenkins master to be restarted (See #89 for link)